### PR TITLE
Added -UseBasicParsing

### DIFF
--- a/CxHealthMonitor.ps1
+++ b/CxHealthMonitor.ps1
@@ -962,7 +962,7 @@ Class EngineMonitor {
         [Object] $resp = $null
         for ($i = 0; $i -lt $script:config.monitor.retries; $i++) {             
             try {     
-                $resp = Invoke-WebRequest -Uri $apiUri -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds
+                $resp = Invoke-WebRequest -UseBasicParsing -Uri $apiUri -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds
                 break
             }
             catch {
@@ -1367,7 +1367,7 @@ Class QueueMonitor {
         [Object] $resp = $null
         [String] $pageUrl = $script:config.cx.host + "/CxWebClient/Login.aspx"
         try {     
-            $resp = Invoke-WebRequest -Uri $pageUrl -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds
+            $resp = Invoke-WebRequest -UseBasicParsing -Uri $pageUrl -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds
         }
         catch {
             $resp = $_.Exception.Response


### PR DESCRIPTION
Fixes issue #11 where if Internet Explorer has not been configured then the script breaks.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ts/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes https://github.com/checkmarx-ts/CxOverwatch/issues/11 where running the script as a user who has never configured Internet Explorer breaks the script.

### References

https://github.com/checkmarx-ts/CxOverwatch/issues/11

### Testing

Tested against my 8.9 HF14 lab using my installer script:

```
# Installs CxOverwatch

$server="http://localhost"
$user="checkmarx"
$password="REDACTED"

$progressPreference = 'silentlyContinue'
[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;


md -force c:\programdata\checkmarx
cd c:\programdata\checkmarx
git clone https://github.com/checkmarx-ts/CxOverwatch.git


$config = @"
{
    "cx": {
        "host": "$server",
        "username": "$user",
        "password": "$password",
        "db": {
            "instance": "localhost\\SQLExpress",
            "username": "",
            "password": ""
        }
    },
    "monitor": {
        "useUTCTimeOnClient": "false",
        "apiResponseTimeoutSeconds": 120,
        "pollIntervalSeconds": 30,
        "thresholds": {
            "queuedScansThreshold": 5,
            "queuedTimeThresholdMinutes": 20,
            "scanDurationThresholdMarginPercent": 25.0,
            "scanRateAsLOCPerHour": 150000,
            "engineResponseThresholdSeconds": 60.0,
            "restResponseThresholdSeconds": 60.0
        },
        "retries": 5
    },
    "alerts": {
        "waitingPeriodBetweenAlertsMinutes": 15,
        "suppressionRegex": ""
    },
    "alertingSystems": {
               
    },
    "log": {
        "jsonDirectory": "json"
    }
}
"@

cd CxOverwatch
mv cx_health_mon_config.json cx_health_mon_config.json.backup
Set-Content cx_health_mon_config.json -Value $config



# Install as scheduled task
$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-File "c:\programdata\checkmarx\CxOverwatch\CxHealthMonitor.ps1"' -WorkingDirectory 'C:\programdata\checkmarx\CxOverwatch'


$principal = New-ScheduledTaskPrincipal "NT AUTHORITY\NETWORK SERVICE"
$restartInterval = new-timespan -minute 5
$settings = New-ScheduledTaskSettingsSet -RestartInterval $restartInterval -RestartCount 864 -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew -DontStopOnIdleEnd -ExecutionTimeLimit 0

$triggers = @(
    $(New-ScheduledTaskTrigger -AtStartup),
    $(New-ScheduledTaskTrigger -Once -At (Get-Date).Date -RepetitionInterval $restartInterval)
)

Register-ScheduledTask -Action $action -Trigger $triggers -Settings $settings -TaskName "Checkmarx CxOverwatch" -Description "Monitors the Checkmarx scan queue, engines, and portal responsiveness." -Principal $principal 

```

Where previously errors were occuring in the log/output, the script is able to run successfully and logging is working:

```
4/15/2020 3:56:18 AM: Queued: 0, Running: 2, Failed: 0, Finished: 0
4/15/2020 3:56:18 AM: Scan [id: 1000172, project: nopCommerce, type: Full, stage: Scanning, loc: 779310, stage/total %: 100/48, engine: 176] Elapsed: [01:36:43.7630000]. Threshold: duration [06:29:39.3000000]
4/15/2020 3:56:18 AM: Scan [id: 1000187, project: DVHMA, type: Full, stage: Scanning, loc: 578633, stage/total %: 54/40, engine: 183] Elapsed: [01:27:50.7870000]. Threshold: duration [04:49:18.9900000]
4/15/2020 3:56:24 AM: Portal is responsive. Portal responded in [6.5145715] seconds.
4/15/2020 3:56:24 AM: Engine [1, Localhost, Blocked] Responded in [0.0134874] seconds.
4/15/2020 3:56:24 AM: Engine [176, **cx-engine-89-M-002, ScanningAndBlocked] Responded in [0.0158788] seconds.
4/15/2020 3:56:24 AM: Engine [183, **cx-engine-89-M-003, ScanningAndBlocked] Responded in [0.0160498] seconds.

```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
