### PR TITLE
BugFix for multiple email recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Follow instructions on creating an incoming webhook for:
                 "host": "007-myemailserver.com",
                 "port": 587,
                 "sender": "admin@myemailserver.com",
-                "recipients": "list@of.com, email@addresses.com",
+                "recipients": ["list@of.com", "email@addresses.com"],
                 "subject": "Checkmarx Health Monitor Alert",
                 "useSsl": true
             }

--- a/cx_health_mon_config.json
+++ b/cx_health_mon_config.json
@@ -31,7 +31,7 @@
                 "host": "smtp.mailserver.com",
                 "port": 587,
                 "sender": "admin@mailserver.com",
-                "recipients": "list@of.com, email@addresses.com",
+                "recipients": ["list@of.com", "email@addresses.com"],
                 "subject": "Checkmarx Health Monitor Alert",
                 "useSsl": true
             }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ts/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

The example config file and readme do not have the smtp alert recipients value correct.  multiple emails need to be added as an array of strings for the PowerShell cmdlet Send-MailMessage to properly read all senders. 

### References

> Include supporting link to GitHub Issue/PR number

### Testing

Update cx_health_mon_config.json and add email addresses to recipients using a json array ["me@company.com", "you@company.com"]

$config = cat .\cx_health_mon_config.json |convertfrom-json

$mailargs = @{
                From = youremail@company.com
                Body = "test Message to multiple senders"
                Subject = "A test"
                To = $config.alertingSystems.smtp.recipients
                Priority = "High"
                SmtpServer = smtp.company.com
                Port = 25
            }
                        
Send-MailMessage @mailargs  # Message will send to both users

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
