### PR TITLE
Fix linux engines url

### DIFF
--- a/CxHealthMonitor.ps1
+++ b/CxHealthMonitor.ps1
@@ -1038,7 +1038,13 @@ Class EngineMonitor {
         for ($i = 0; $i -lt $script:config.monitor.retries; $i++) {             
             try {
                 if($this.cxVersion.StartsWith("9.3")){
-                    $resp = Invoke-WebRequest -UseBasicParsing -Uri "${apiUri}/swagger/index.html" -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds
+                    # fix because on sast engine version 9.3hf16 the url like http://192.168.1.1:8088//swagger/index.html is not working because of the two / before swagger
+                    if($apiUri -match '/$'){
+                        $newApiUri = ("{0}{1}" -f ${apiUri},"swagger/index.html")
+                    }else{
+                        $newApiUri = "${apiUri}/swagger/index.html"
+                    }
+                    $resp = Invoke-WebRequest -UseBasicParsing -Uri $newApiUri -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds
                     break
                 } else{
                     $resp = Invoke-WebRequest -UseBasicParsing -Uri $apiUri -TimeoutSec $script:config.monitor.apiResponseTimeoutSeconds


### PR DESCRIPTION
Discovery on some customers after an update the engines on version 9.3HF16 were throwing errors. The error was in the construct of the engine swagger url where the two // before swagger don't work as an endpoint.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](https://github.com/checkmarx-ts/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/checkmarx-ts/open-source-template/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This pull request is to fix the issue were URI that have double / cause a failure on engine swagger.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentaiton is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
